### PR TITLE
Allow user to define custom filtered parameters

### DIFF
--- a/param_logger.go
+++ b/param_logger.go
@@ -27,13 +27,19 @@ type parameterLogger struct {
 	excluded []string
 }
 
+func ParameterLoggerFiltering(customParams []string) buffalo.MiddlewareFunc {
+	return func(next buffalo.Handler) buffalo.Handler {
+		pl := parameterLogger{
+			excluded: append(ParameterExclusionList, customParams...),
+		}
+
+		return pl.Middleware(next)
+	}
+}
+
 // ParameterLogger logs form and parameter values to the loggers
 func ParameterLogger(next buffalo.Handler) buffalo.Handler {
-	pl := parameterLogger{
-		excluded: ParameterExclusionList,
-	}
-
-	return pl.Middleware(next)
+	return ParameterLoggerFiltering([]string{})(next)
 }
 
 // Middleware is a buffalo middleware function to connect this parameter filterer with buffalo


### PR DESCRIPTION
Adds a new function, `ParameterLoggerFiltering`, that provides an easy interface to add parameters that should be filtered. These are in addition to the default parameters.

```
app.Use(ParameterLoggerFiltering([]string{"should_be_filtered", "this_too"}))
```

`ParameterLogger` works exactly as before, but uses `ParameterLoggerFiltering` with no additional parameters for DRY-ness.